### PR TITLE
Add backend service tests

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -135,13 +135,18 @@
 			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>postgresql</artifactId>
-			<version>${testcontainers.version}</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.testcontainers</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <version>${testcontainers.version}</version>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/backend/src/main/java/com/fatayertime/backend/controller/AdminController.java
+++ b/backend/src/main/java/com/fatayertime/backend/controller/AdminController.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("api/admin")
@@ -42,7 +43,7 @@ public class AdminController {
 
     // ✅ Update menu item
     @PutMapping("/menu/{id}")
-    public ResponseEntity<MenuItem> updateMenuItem(@PathVariable Long id, @RequestBody MenuItem updatedItem) {
+    public ResponseEntity<MenuItem> updateMenuItem(@PathVariable UUID id, @RequestBody MenuItem updatedItem) {
         return menuRepo.findById(id)
                 .map(item -> {
                     item.setName(updatedItem.getName());
@@ -58,7 +59,7 @@ public class AdminController {
 
     // ✅ Delete menu item
     @DeleteMapping("/menu/{id}")
-    public ResponseEntity<?> deleteMenuItem(@PathVariable Long id) {
+    public ResponseEntity<?> deleteMenuItem(@PathVariable UUID id) {
         if (menuRepo.existsById(id)) {
             menuRepo.deleteById(id);
             return ResponseEntity.ok().build();

--- a/backend/src/main/java/com/fatayertime/backend/repository/MenuItemRepository.java
+++ b/backend/src/main/java/com/fatayertime/backend/repository/MenuItemRepository.java
@@ -2,11 +2,11 @@ package com.fatayertime.backend.repository;
 
 import com.fatayertime.backend.model.MenuItem;
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
-public interface MenuItemRepository extends JpaRepository<MenuItem, Long> {
+public interface MenuItemRepository extends JpaRepository<MenuItem, UUID> {
 
     // Find single item by exact name match
     Optional<MenuItem> findByName(String name);

--- a/backend/src/main/java/com/fatayertime/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/fatayertime/backend/repository/UserRepository.java
@@ -5,8 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 
 import java.util.Optional;
+import java.util.UUID;
 
-public interface UserRepository extends JpaRepository<AppUser, Long> {
+public interface UserRepository extends JpaRepository<AppUser, UUID> {
     Optional<AppUser> findByUsername(String username);
     boolean existsByUsername(String username);
 }

--- a/backend/src/main/java/com/fatayertime/backend/service/MenuItemService.java
+++ b/backend/src/main/java/com/fatayertime/backend/service/MenuItemService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -26,7 +27,7 @@ public class MenuItemService {
 
     // Read
     @Transactional(readOnly = true)
-    public MenuItem getMenuItemById(Long id) {
+    public MenuItem getMenuItemById(UUID id) {
         log.debug("Fetching menu item with id: {}", id);
         return menuItemRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Menu item not found with id: " + id));
@@ -46,7 +47,7 @@ public class MenuItemService {
 
     // Update
     @Transactional
-    public MenuItem updateMenuItem(Long id, MenuItem updatedItem) {
+    public MenuItem updateMenuItem(UUID id, MenuItem updatedItem) {
         log.info("Updating menu item with id: {}", id);
         MenuItem existingItem = menuItemRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Menu item not found with id: " + id));
@@ -78,7 +79,7 @@ public class MenuItemService {
 
     // Delete
     @Transactional
-    public void deleteMenuItem(Long id) {
+    public void deleteMenuItem(UUID id) {
         log.info("Deleting menu item with id: {}", id);
         if (!menuItemRepository.existsById(id)) {
             throw new EntityNotFoundException("Menu item not found with id: " + id);

--- a/backend/src/test/java/com/fatayertime/backend/AuthControllerTests.java
+++ b/backend/src/test/java/com/fatayertime/backend/AuthControllerTests.java
@@ -1,0 +1,46 @@
+package com.fatayertime.backend;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(locations = "classpath:application-test.properties")
+class AuthControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void loginWithValidCredentialsReturnsToken() throws Exception {
+        String body = "{\"username\":\"admin\",\"password\":\"admin123\"}";
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(header().exists(HttpHeaders.AUTHORIZATION))
+                .andExpect(jsonPath("$.token").isNotEmpty())
+                .andExpect(jsonPath("$.message").value("Login successful"));
+    }
+
+    @Test
+    void loginWithInvalidCredentialsReturnsUnauthorized() throws Exception {
+        String body = "{\"username\":\"admin\",\"password\":\"wrong\"}";
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized());
+    }
+}
+

--- a/backend/src/test/java/com/fatayertime/backend/JwtUtilTests.java
+++ b/backend/src/test/java/com/fatayertime/backend/JwtUtilTests.java
@@ -1,0 +1,27 @@
+package com.fatayertime.backend;
+
+import com.fatayertime.backend.config.JwtUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class JwtUtilTests {
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Test
+    void generateAndValidateToken() {
+        String username = "testuser";
+
+        String token = jwtUtil.generateToken(username);
+
+        assertThat(jwtUtil.extractUsername(token)).isEqualTo(username);
+        assertThat(jwtUtil.validateToken(token, username)).isTrue();
+        assertThat(jwtUtil.validateToken(token, "other")).isFalse();
+    }
+}
+

--- a/backend/src/test/java/com/fatayertime/backend/MenuItemServiceTests.java
+++ b/backend/src/test/java/com/fatayertime/backend/MenuItemServiceTests.java
@@ -1,0 +1,56 @@
+package com.fatayertime.backend;
+
+import com.fatayertime.backend.model.MenuItem;
+import com.fatayertime.backend.repository.MenuItemRepository;
+import com.fatayertime.backend.service.MenuItemService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@TestPropertySource(locations = "classpath:application-test.properties")
+class MenuItemServiceTests {
+
+    @Autowired
+    private MenuItemService service;
+
+    @Autowired
+    private MenuItemRepository repository;
+
+    @Test
+    void menuItemCrudOperations() {
+        MenuItem item = MenuItem.builder()
+                .name("Test Item")
+                .description("desc")
+                .price(1.0)
+                .category("TEST")
+                .imageUrl("img")
+                .ingredients("ing")
+                .isVegetarian(true)
+                .build();
+
+        MenuItem saved = service.createMenuItem(item);
+        UUID id = saved.getId();
+        assertThat(repository.existsById(id)).isTrue();
+
+        MenuItem fetched = service.getMenuItemById(id);
+        assertThat(fetched.getName()).isEqualTo("Test Item");
+
+        MenuItem update = new MenuItem();
+        update.setName("Updated Item");
+        update.setPrice(2.5);
+        MenuItem updated = service.updateMenuItem(id, update);
+
+        assertThat(updated.getName()).isEqualTo("Updated Item");
+        assertThat(updated.getPrice()).isEqualTo(2.5);
+
+        service.deleteMenuItem(id);
+        assertThat(repository.existsById(id)).isFalse();
+    }
+}
+

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
## Summary
- add H2 test dependency
- switch repositories and services to use `UUID`
- support UUID IDs in `AdminController`
- create test configuration for H2
- add tests for JWT utilities, authentication, and menu CRUD

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_6873eb427cc88332808187f8fea47ee7